### PR TITLE
chore: cleanup build line

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,9 @@ source:
 
 build:
   number: 0
-  script: CMAKE_BUILD_PARALLEL_LEVEL=1 {{ PYTHON }} -m pip install . -vv  # [linux and ppc64le]
-  script: {{ PYTHON }} -m pip install . -vv  # [not (linux and ppc64le)]
+  script:
+    - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+    - {{ PYTHON }} -m pip install . -vvv
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

No changes, just tidying up the build expression, so no new version number needed. This might need to still be limited to 1 thread on Travis, but maybe CPU_COUNT (probably 2?) will work as the thread count may possibly be much higher.

See https://github.com/conda-forge/boost-histogram-feedstock/pull/27 for the same sort of cleanup.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
